### PR TITLE
Update white-list.sorl

### DIFF
--- a/white-list.sorl
+++ b/white-list.sorl
@@ -99,7 +99,6 @@
 *.fir.im
 *.fliggy.com
 *.foundertype.com
-*.github.io
 *.googletagmanager.com
 *.gratisography.com
 *.growingio.com


### PR DESCRIPTION
Github.io is no longer accessible.