### PR TITLE
Update white-list.sorl

### DIFF
--- a/white-list.sorl
+++ b/white-list.sorl
@@ -57,7 +57,6 @@
 *.babybus.com
 *.baidu.com
 *.baiduwp.com
-*.bandwagonhost.com
 *.baomihua.com
 *.bbtree.com
 *.beisen.com


### PR DESCRIPTION
bandwagonhost.com  is no longer accessible.